### PR TITLE
Fix keyboard navigation resume

### DIFF
--- a/src/components/BookmarkTable.vue
+++ b/src/components/BookmarkTable.vue
@@ -29,14 +29,14 @@
       :selected-items="selectedItems"
       :server-options="localServerOptions"
       :total-items="totalItems"
+      @edit="handleEdit"
       @expand-domain="handleExpandDomain"
+      @search-tag="handleSearchTag"
       @single-delete="handleSingleDelete"
       @toggle-item-selection="toggleItemSelection"
       @toggle-select-all="toggleSelectAll"
       @update-page="changePage"
       @view-details="handleViewDetails"
-      @edit="handleEdit"
-      @search-tag="handleSearchTag"
     />
 
     <!-- TABLE VIEW: Desktop only when selected -->
@@ -48,10 +48,10 @@
       :collapsed-domains="collapsedDomainsWithCounts"
       :expanding-domain="expandingDomain"
       :focused-row-index="focusedRowIndex"
-      :remembered-focus-index="rememberedFocusIndex"
       :is-all-selected="isAllSelected"
       :is-indeterminate="isIndeterminate"
       :loading="loading"
+      :remembered-focus-index="rememberedFocusIndex"
       :search-term="searchTerm"
       :search-type="searchType"
       :selected-items="selectedItems"
@@ -85,335 +85,290 @@
 </template>
 
 <script setup>
-import { computed, nextTick, onMounted, onUnmounted, ref, toRef, watch } from 'vue'
-import { useRouter } from 'vue-router'
-import { useDisplay } from 'vuetify'
-import AppTips from '@/components/AppTips.vue'
-import BookmarkCardView from '@/components/BookmarkCardView.vue'
-import BookmarkDeleteButton from '@/components/BookmarkDeleteButton.vue'
-import BookmarkDetailsDialog from '@/components/BookmarkDetailsDialog.vue'
-import BookmarkEditDialog from '@/components/BookmarkEditDialog.vue'
-import BookmarkTableView from '@/components/BookmarkTableView.vue'
-import PageNavigationIndicator from '@/components/PageNavigationIndicator.vue'
-import { useBookmarkData } from '@/composables/useBookmarkData'
-import { useBookmarkTableDialogs } from '@/composables/useBookmarkTableDialogs'
-import { useBookmarkTableKeyboard } from '@/composables/useBookmarkTableKeyboard'
-import { useBookmarkTableState } from '@/composables/useBookmarkTableState'
-import { useDomainCollapsing } from '@/composables/useDomainCollapsing'
-import { useNumericPagination } from '@/composables/useNumericPagination'
-import { useTableSelection } from '@/composables/useTableSelection'
-import { useUserPreferences } from '@/composables/useUserPreferences'
-import { useAppStore } from '@/stores/app'
-import { useViewModeStore } from '@/stores/viewMode'
+  import { computed, nextTick, onMounted, onUnmounted, ref, toRef, watch } from 'vue'
+  import { useRouter } from 'vue-router'
+  import { useDisplay } from 'vuetify'
+  import AppTips from '@/components/AppTips.vue'
+  import BookmarkCardView from '@/components/BookmarkCardView.vue'
+  import BookmarkDeleteButton from '@/components/BookmarkDeleteButton.vue'
+  import BookmarkDetailsDialog from '@/components/BookmarkDetailsDialog.vue'
+  import BookmarkEditDialog from '@/components/BookmarkEditDialog.vue'
+  import BookmarkTableView from '@/components/BookmarkTableView.vue'
+  import PageNavigationIndicator from '@/components/PageNavigationIndicator.vue'
+  import { useBookmarkData } from '@/composables/useBookmarkData'
+  import { useBookmarkTableDialogs } from '@/composables/useBookmarkTableDialogs'
+  import { useBookmarkTableKeyboard } from '@/composables/useBookmarkTableKeyboard'
+  import { useBookmarkTableState } from '@/composables/useBookmarkTableState'
+  import { useDomainCollapsing } from '@/composables/useDomainCollapsing'
+  import { useNumericPagination } from '@/composables/useNumericPagination'
+  import { useTableSelection } from '@/composables/useTableSelection'
+  import { useUserPreferences } from '@/composables/useUserPreferences'
+  import { useAppStore } from '@/stores/app'
+  import { useViewModeStore } from '@/stores/viewMode'
 
-const props = defineProps({
-  dialogOpen: Boolean,
-  selectedItems: Array,
-  searchType: {
-    type: String,
-    default: 'all',
-  },
-  searchTerm: {
-    type: String,
-    default: '',
-  },
-})
-
-const emit = defineEmits(['update:selected-items', 'bookmark-updated', 'delete-selected'])
-
-const appStore = useAppStore()
-const router = useRouter()
-const { mobile } = useDisplay()
-const { domainCollapsing, itemsPerPage: userItemsPerPage } = useUserPreferences()
-const viewModeStore = useViewModeStore()
-
-// View mode state - mobile always uses card, desktop can choose
-const currentViewMode = computed(() => viewModeStore.mode)
-
-// Create reactive refs from props
-const reactiveSearchType = toRef(props, 'searchType')
-const reactiveSearchTerm = toRef(props, 'searchTerm')
-
-// Table key for forcing re-renders
-const tableKey = computed(() => `${props.searchType}-${props.searchTerm}-table`)
-
-// Create a table ref to access the component directly
-const dataTableRef = ref(null)
-
-// Data management
-const {
-  loading,
-  bookmarks,
-  totalItems,
-  serverOptions,
-  loadBookmarks,
-  updateServerOptions,
-  resetPagination,
-  expandDomain,
-  expandedDomains,
-} = useBookmarkData(appStore, reactiveSearchType, reactiveSearchTerm, userItemsPerPage)
-
-// State management for server options and preferences
-const { localServerOptions, userPreferencesStable } = useBookmarkTableState(
-  serverOptions,
-  userItemsPerPage,
-  updateServerOptions
-)
-
-// Selection logic
-const {
-  isAllSelected,
-  isIndeterminate,
-  toggleSelectAll,
-  toggleItemSelection,
-} = useTableSelection(bookmarks, toRef(props, 'selectedItems'), emit)
-
-// Domain collapsing functionality
-const {
-  displayBookmarks,
-  collapsedDomainsWithCounts,
-  expandingDomain,
-  handleExpandDomain: handleDomainExpand,
-} = useDomainCollapsing(
-  bookmarks,
-  domainCollapsing,
-  expandedDomains,
-  expandDomain,
-  loadBookmarks,
-  serverOptions,
-)
-
-// Dialog management
-const {
-  detailsDialog,
-  editDialog,
-  detailsBookmark,
-  editBookmark,
-  dialogsOpen,
-  handleViewDetails,
-  handleEdit,
-  handleBookmarkUpdated,
-} = useBookmarkTableDialogs(emit, loadBookmarks)
-
-// Keyboard navigation - only for desktop table view
-const {
-  focusedRowIndex,
-  rememberedFocusIndex,
-  restoreFocus,
-  clearRememberedFocus,
-} = useBookmarkTableKeyboard(
-  displayBookmarks,
-  toRef(props, 'selectedItems'),
-  toggleItemSelection,
-  dialogsOpen,
-  router,
-  handleEdit,
-  handleViewDetails,
-)
-
-// Numeric pagination
-const { numberBuffer, errorMessage } = useNumericPagination(
-  pageNumber => {
-    if (!userPreferencesStable.value) return
-
-    const newOptions = {
-      ...localServerOptions.value,
-      page: pageNumber,
-    }
-
-    localServerOptions.value = newOptions
-
-    nextTick(() => {
-      if (dataTableRef.value) {
-        handleOptionsUpdate(localServerOptions.value)
-      }
-
-      nextTick(() => {
-        const clonedOptions = structuredClone(localServerOptions.value)
-        localServerOptions.value = clonedOptions
-      })
-    })
-  },
-  () => Math.ceil(totalItems.value / localServerOptions.value.itemsPerPage),
-  () => Object.values(dialogsOpen.value).some(Boolean),
-)
-
-// Custom keyboard navigation that uses remembered focus
-function handleTableNavigate(direction) {
-  if (mobile.value || currentViewMode.value !== 'table') return
-  
-  const bookmarkCount = displayBookmarks.value.length
-  if (bookmarkCount === 0) return
-
-  let newIndex
-  // Use remembered focus index if no current focus, otherwise use current focus
-  const startIndex = focusedRowIndex.value >= 0 ? focusedRowIndex.value : (rememberedFocusIndex.value >= 0 ? rememberedFocusIndex.value : -1)
-
-  if (direction === 'down') {
-    newIndex = startIndex < bookmarkCount - 1 ? startIndex + 1 : 0
-  } else if (direction === 'up') {
-    newIndex = startIndex > 0 ? startIndex - 1 : bookmarkCount - 1
-  } else {
-    return
-  }
-
-  // Update both focus indexes
-  focusedRowIndex.value = newIndex
-  rememberedFocusIndex.value = newIndex
-  
-  // Focus the DOM element
-  setTimeout(() => {
-    const rowElement = document.querySelector(`[data-bookmark-row-index="${newIndex}"]`)
-    if (rowElement) {
-      rowElement.focus({ preventScroll: false })
-      rowElement.scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
-      })
-    }
-  }, 0)
-}
-
-// Override keyboard navigation events
-onMounted(() => {
-  if (mobile.value) {
-    viewModeStore.setMode('card')
-  } else {
-    viewModeStore.initialize()
-  }
-
-  // Listen for view mode change events from command palette
-  document.addEventListener('change-view-mode', handleViewModeCommand)
-  
-  // Override the table navigation events to use our custom logic
-  document.addEventListener('table-arrow-down', (e) => {
-    e.preventDefault?.()
-    handleTableNavigate('down')
+  const props = defineProps({
+    dialogOpen: Boolean,
+    selectedItems: Array,
+    searchType: {
+      type: String,
+      default: 'all',
+    },
+    searchTerm: {
+      type: String,
+      default: '',
+    },
   })
-  document.addEventListener('table-arrow-up', (e) => {
-    e.preventDefault?.()
-    handleTableNavigate('up')
-  })
-})
 
-onUnmounted(() => {
-  document.removeEventListener('change-view-mode', handleViewModeCommand)
-  // Clean up our custom handlers
-  document.removeEventListener('table-arrow-down', handleTableNavigate)
-  document.removeEventListener('table-arrow-up', handleTableNavigate)
-})
+  const emit = defineEmits(['update:selected-items', 'bookmark-updated', 'delete-selected'])
 
-// Watch for mobile changes and force card view
-watch(() => mobile.value, isMobile => {
-  if (isMobile) {
-    viewModeStore.setMode('card')
-  }
-})
+  const appStore = useAppStore()
+  const router = useRouter()
+  const { mobile } = useDisplay()
+  const { domainCollapsing, itemsPerPage: userItemsPerPage } = useUserPreferences()
+  const viewModeStore = useViewModeStore()
 
-// Watch for dialog state changes to restore focus when dialogs close (table view only)
-watch(dialogsOpen, (newDialogsOpen, oldDialogsOpen) => {
-  if (mobile.value || currentViewMode.value !== 'table') return
+  // View mode state - mobile always uses card, desktop can choose
+  const currentViewMode = computed(() => viewModeStore.mode)
 
-  const dialogJustClosed = Object.keys(newDialogsOpen).some(key =>
-    oldDialogsOpen?.[key] === true && newDialogsOpen[key] === false,
+  // Create reactive refs from props
+  const reactiveSearchType = toRef(props, 'searchType')
+  const reactiveSearchTerm = toRef(props, 'searchTerm')
+
+  // Table key for forcing re-renders
+  const tableKey = computed(() => `${props.searchType}-${props.searchTerm}-table`)
+
+  // Create a table ref to access the component directly
+  const dataTableRef = ref(null)
+
+  // Data management
+  const {
+    loading,
+    bookmarks,
+    totalItems,
+    serverOptions,
+    loadBookmarks,
+    updateServerOptions,
+    resetPagination,
+    expandDomain,
+    expandedDomains,
+  } = useBookmarkData(appStore, reactiveSearchType, reactiveSearchTerm, userItemsPerPage)
+
+  // State management for server options and preferences
+  const { localServerOptions, userPreferencesStable } = useBookmarkTableState(
+    serverOptions,
+    userItemsPerPage,
+    updateServerOptions,
   )
 
-  if (dialogJustClosed) {
-    setTimeout(() => {
-      restoreFocus()
-    }, 150)
+  // Selection logic
+  const {
+    isAllSelected,
+    isIndeterminate,
+    toggleSelectAll,
+    toggleItemSelection,
+  } = useTableSelection(bookmarks, toRef(props, 'selectedItems'), emit)
+
+  // Domain collapsing functionality
+  const {
+    displayBookmarks,
+    collapsedDomainsWithCounts,
+    expandingDomain,
+    handleExpandDomain: handleDomainExpand,
+  } = useDomainCollapsing(
+    bookmarks,
+    domainCollapsing,
+    expandedDomains,
+    expandDomain,
+    loadBookmarks,
+    serverOptions,
+  )
+
+  // Dialog management
+  const {
+    detailsDialog,
+    editDialog,
+    detailsBookmark,
+    editBookmark,
+    dialogsOpen,
+    handleViewDetails,
+    handleEdit,
+    handleBookmarkUpdated,
+  } = useBookmarkTableDialogs(emit, loadBookmarks)
+
+  // Keyboard navigation - only for desktop table view
+  const {
+    focusedRowIndex,
+    rememberedFocusIndex,
+    restoreFocus,
+    clearRememberedFocus,
+  } = useBookmarkTableKeyboard(
+    displayBookmarks,
+    toRef(props, 'selectedItems'),
+    toggleItemSelection,
+    dialogsOpen,
+    router,
+    handleEdit,
+    handleViewDetails,
+  )
+
+  // Numeric pagination
+  const { numberBuffer, errorMessage } = useNumericPagination(
+    pageNumber => {
+      if (!userPreferencesStable.value) return
+
+      const newOptions = {
+        ...localServerOptions.value,
+        page: pageNumber,
+      }
+
+      localServerOptions.value = newOptions
+
+      nextTick(() => {
+        if (dataTableRef.value) {
+          handleOptionsUpdate(localServerOptions.value)
+        }
+
+        nextTick(() => {
+          const clonedOptions = structuredClone(localServerOptions.value)
+          localServerOptions.value = clonedOptions
+        })
+      })
+    },
+    () => Math.ceil(totalItems.value / localServerOptions.value.itemsPerPage),
+    () => Object.values(dialogsOpen.value).some(Boolean),
+  )
+
+  // Listen for custom table navigation events (handled in useBookmarkTableKeyboard)
+
+  // Override keyboard navigation events
+  onMounted(() => {
+    if (mobile.value) {
+      viewModeStore.setMode('card')
+    } else {
+      viewModeStore.initialize()
+    }
+
+    // Listen for view mode change events from command palette
+    document.addEventListener('change-view-mode', handleViewModeCommand)
+
+  // No table navigation handlers here
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('change-view-mode', handleViewModeCommand)
+  // No additional listeners to remove (handled in composable)
+  })
+
+  // Watch for mobile changes and force card view
+  watch(() => mobile.value, isMobile => {
+    if (isMobile) {
+      viewModeStore.setMode('card')
+    }
+  })
+
+  // Watch for dialog state changes to restore focus when dialogs close (table view only)
+  watch(dialogsOpen, (newDialogsOpen, oldDialogsOpen) => {
+    if (mobile.value || currentViewMode.value !== 'table') return
+
+    const dialogJustClosed = Object.keys(newDialogsOpen).some(key =>
+      oldDialogsOpen?.[key] === true && newDialogsOpen[key] === false,
+    )
+
+    if (dialogJustClosed) {
+      setTimeout(() => {
+        restoreFocus()
+      }, 150)
+    }
+  }, { deep: true })
+
+  // Watch for edit/details dialogs specifically for additional safety (table view only)
+  watch([() => editDialog.value, () => detailsDialog.value], ([newEdit, newDetails], [oldEdit, oldDetails]) => {
+    if (mobile.value || currentViewMode.value !== 'table') return
+
+    if ((oldEdit && !newEdit) || (oldDetails && !newDetails)) {
+      setTimeout(() => {
+        restoreFocus()
+      }, 150)
+    }
+  })
+
+  // Watch for bookmark data changes and clear remembered focus if bookmarks change significantly (table view only)
+  watch(() => displayBookmarks.value.length, (newLength, oldLength) => {
+    if (mobile.value || currentViewMode.value !== 'table') return
+
+    if (oldLength !== undefined && Math.abs(newLength - oldLength) > 1) {
+      clearRememberedFocus()
+    }
+  })
+
+  // Watch for prop changes and reload data
+  watch([reactiveSearchType, reactiveSearchTerm], () => {
+    resetPagination()
+    loadBookmarks()
+  }, { immediate: false })
+
+  // Watch for changes in user's items per page preference
+  watch(userItemsPerPage, newItemsPerPage => {
+    localServerOptions.value = {
+      ...localServerOptions.value,
+      itemsPerPage: newItemsPerPage,
+      page: 1,
+    }
+  }, { immediate: false })
+
+  // Event handlers
+  function handleViewModeCommand (event) {
+    const { mode } = event.detail
+    if (!mobile.value && ['table', 'card'].includes(mode)) {
+      viewModeStore.setMode(mode)
+    }
   }
-}, { deep: true })
 
-// Watch for edit/details dialogs specifically for additional safety (table view only)
-watch([() => editDialog.value, () => detailsDialog.value], ([newEdit, newDetails], [oldEdit, oldDetails]) => {
-  if (mobile.value || currentViewMode.value !== 'table') return
+  function handleRowClicked (index) {
+    if (mobile.value || currentViewMode.value !== 'table') return
 
-  if ((oldEdit && !newEdit) || (oldDetails && !newDetails)) {
-    setTimeout(() => {
-      restoreFocus()
-    }, 150)
-  }
-})
-
-// Watch for bookmark data changes and clear remembered focus if bookmarks change significantly (table view only)
-watch(() => displayBookmarks.value.length, (newLength, oldLength) => {
-  if (mobile.value || currentViewMode.value !== 'table') return
-
-  if (oldLength !== undefined && Math.abs(newLength - oldLength) > 1) {
-    clearRememberedFocus()
-  }
-})
-
-// Watch for prop changes and reload data
-watch([reactiveSearchType, reactiveSearchTerm], () => {
-  resetPagination()
-  loadBookmarks()
-}, { immediate: false })
-
-// Watch for changes in user's items per page preference
-watch(userItemsPerPage, newItemsPerPage => {
-  localServerOptions.value = {
-    ...localServerOptions.value,
-    itemsPerPage: newItemsPerPage,
-    page: 1,
-  }
-}, { immediate: false })
-
-// Event handlers
-function handleViewModeCommand(event) {
-  const { mode } = event.detail
-  if (!mobile.value && ['table', 'card'].includes(mode)) {
-    viewModeStore.setMode(mode)
-  }
-}
-
-function handleRowClicked(index) {
-  if (mobile.value || currentViewMode.value !== 'table') return
-  
-  // Update the remembered focus index when a row is manually clicked
-  rememberedFocusIndex.value = index
-}
-
-function handleRowFocusChanged(index, isFocused) {
-  if (mobile.value || currentViewMode.value !== 'table') return
-
-  if (isFocused) {
-    focusedRowIndex.value = index
-    // Also update remembered focus when navigating with keyboard
+    // Update the remembered focus index when a row is manually clicked
     rememberedFocusIndex.value = index
-  } else if (focusedRowIndex.value === index) {
-    focusedRowIndex.value = -1
   }
-}
 
-function handleOptionsUpdate(newOptions) {
-  localServerOptions.value = { ...newOptions }
-}
+  function handleRowFocusChanged (index, isFocused) {
+    if (mobile.value || currentViewMode.value !== 'table') return
 
-function changePage(newPage) {
-  localServerOptions.value = {
-    ...localServerOptions.value,
-    page: newPage,
+    if (isFocused) {
+      focusedRowIndex.value = index
+      // Also update remembered focus when navigating with keyboard
+      rememberedFocusIndex.value = index
+    } else if (focusedRowIndex.value === index) {
+      focusedRowIndex.value = -1
+    }
   }
-}
 
-function handleSingleDelete(item) {
-  emit('update:selected-items', [item.id])
-}
+  function handleOptionsUpdate (newOptions) {
+    localServerOptions.value = { ...newOptions }
+  }
 
-function handleSearchTag(tag) {
-  router.push(`/tag/${encodeURIComponent(tag)}`)
-}
+  function changePage (newPage) {
+    localServerOptions.value = {
+      ...localServerOptions.value,
+      page: newPage,
+    }
+  }
 
-function handleExpandDomain(domain) {
-  handleDomainExpand(domain)
-}
+  function handleSingleDelete (item) {
+    emit('update:selected-items', [item.id])
+  }
 
-function handleDeleteCompleted(deletedIds) {
-  emit('update:selected-items', [])
-  loadBookmarks()
-  emit('delete-selected', deletedIds)
-}
+  function handleSearchTag (tag) {
+    router.push(`/tag/${encodeURIComponent(tag)}`)
+  }
+
+  function handleExpandDomain (domain) {
+    handleDomainExpand(domain)
+  }
+
+  function handleDeleteCompleted (deletedIds) {
+    emit('update:selected-items', [])
+    loadBookmarks()
+    emit('delete-selected', deletedIds)
+  }
 </script>

--- a/src/composables/useBookmarkTableKeyboard.js
+++ b/src/composables/useBookmarkTableKeyboard.js
@@ -124,11 +124,20 @@ export function useBookmarkTableKeyboard (
   // }
 
   // Keyboard navigation functions
+  function getCurrentIndex () {
+    return focusedRowIndex.value >= 0
+      ? focusedRowIndex.value
+      : (rememberedFocusIndex.value >= 0
+          ? rememberedFocusIndex.value
+          : -1)
+  }
+
   function handleTableNavigateNext () {
     const bookmarkCount = bookmarks.value.length
     if (!hasOpenDialogs() && bookmarkCount > 0) {
-      const newIndex = focusedRowIndex.value < bookmarkCount - 1
-        ? focusedRowIndex.value + 1
+      const startIndex = getCurrentIndex()
+      const newIndex = startIndex < bookmarkCount - 1
+        ? startIndex + 1
         : 0
       focusRow(newIndex)
     }
@@ -137,8 +146,9 @@ export function useBookmarkTableKeyboard (
   function handleTableNavigatePrev () {
     const bookmarkCount = bookmarks.value.length
     if (!hasOpenDialogs() && bookmarkCount > 0) {
-      const newIndex = focusedRowIndex.value > 0
-        ? focusedRowIndex.value - 1
+      const startIndex = getCurrentIndex()
+      const newIndex = startIndex > 0
+        ? startIndex - 1
         : bookmarkCount - 1
       focusRow(newIndex)
     }
@@ -150,26 +160,6 @@ export function useBookmarkTableKeyboard (
       if (item) {
         toggleItemSelection(item.id)
       }
-    }
-  }
-
-  function handleTableArrowDown () {
-    const bookmarkCount = bookmarks.value.length
-    if (!hasOpenDialogs() && bookmarkCount > 0) {
-      const newIndex = focusedRowIndex.value < bookmarkCount - 1
-        ? focusedRowIndex.value + 1
-        : 0
-      focusRow(newIndex)
-    }
-  }
-
-  function handleTableArrowUp () {
-    const bookmarkCount = bookmarks.value.length
-    if (!hasOpenDialogs() && bookmarkCount > 0) {
-      const newIndex = focusedRowIndex.value > 0
-        ? focusedRowIndex.value - 1
-        : bookmarkCount - 1
-      focusRow(newIndex)
     }
   }
 
@@ -234,8 +224,6 @@ export function useBookmarkTableKeyboard (
     document.addEventListener('table-navigate-next', handleTableNavigateNext)
     document.addEventListener('table-navigate-prev', handleTableNavigatePrev)
     document.addEventListener('table-toggle-selection', handleTableToggleSelection)
-    document.addEventListener('table-arrow-down', handleTableArrowDown)
-    document.addEventListener('table-arrow-up', handleTableArrowUp)
     document.addEventListener('table-clear-focus', handleTableClearFocus)
     document.addEventListener('table-edit-focused', handleTableEditFocused)
     document.addEventListener('table-view-details-focused', handleTableViewDetailsFocused)
@@ -247,8 +235,6 @@ export function useBookmarkTableKeyboard (
     document.removeEventListener('table-navigate-next', handleTableNavigateNext)
     document.removeEventListener('table-navigate-prev', handleTableNavigatePrev)
     document.removeEventListener('table-toggle-selection', handleTableToggleSelection)
-    document.removeEventListener('table-arrow-down', handleTableArrowDown)
-    document.removeEventListener('table-arrow-up', handleTableArrowUp)
     document.removeEventListener('table-clear-focus', handleTableClearFocus)
     document.removeEventListener('table-edit-focused', handleTableEditFocused)
     document.removeEventListener('table-view-details-focused', handleTableViewDetailsFocused)


### PR DESCRIPTION
## Summary
- modify keyboard navigation logic to track the last focused row
- avoid double handling of arrow key events

## Testing
- `npx eslint src/composables/useBookmarkTableKeyboard.js --fix`

------
https://chatgpt.com/codex/tasks/task_e_688015d07b50832f96c82ba4f7259069